### PR TITLE
Revert "Remove the zip archive after downloading the models"

### DIFF
--- a/cmake/add_spleeter_models.cmake
+++ b/cmake/add_spleeter_models.cmake
@@ -27,7 +27,6 @@ if (NOT "${sha256}" STREQUAL "${expected_sha256}")
     COMMAND ${CMAKE_COMMAND} -E tar -xf ${zip_file}
     WORKING_DIRECTORY ${spleeter_models_dir}
   )
-  file(REMOVE ${zip_path})  # Cleanup
 endif()
 
 # ----------------------------------
@@ -56,6 +55,5 @@ if (${spleeter_enable_filter})
       COMMAND ${CMAKE_COMMAND} -E tar -xf ${zip_file}
       WORKING_DIRECTORY ${spleeter_filter_models_dir}
     )
-    file(REMOVE ${zip_path})  # Cleanup
   endif()
 endif()


### PR DESCRIPTION
This reverts commit f2efdb486c8425c9f1e73e81ff42ba858a8bd6fe. It caused
unnecessary and slow redownloads of the model each time the CMake build
is reconfigured. That makes it impossible to use this project via
CMake's ExternalProject_Add() mechanism without massively increasing
configure/build time, bandwidth usage and disk write cycles.