### PR TITLE
Updates for Linux and GTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 build
 docs/build
+
+# Ignore CLion files
+cmake-build-debug
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.28.1)
 
 project(spleeter++)
 
 set(CMAKE_CXX_STANDARD 14)
 
 option(spleeter_enable_tests "Enable unit tests" ON)
+option(spleeter_download_models "Download the models from the spleeter repository" ON)
 option(spleeter_regenerate_models "Build the models from deezer/spleeter repository (requires conda)" OFF)
 option(spleeter_enable_filter "Enable the filter interface (for online processing)" ON)
 option(spleeter_enable_high_resolution "Process the spectrum up the 16KHz" OFF)
@@ -36,7 +37,9 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 if (${spleeter_regenerate_models})
   include(add_spleeter)
 else()
-  include(add_spleeter_models)
+  if(${spleeter_download_models})
+    include(add_spleeter_models)
+  endif()
 endif()
 include(add_eigen)
 include(add_tensorflow)

--- a/cmake/add_googletest.cmake
+++ b/cmake/add_googletest.cmake
@@ -3,7 +3,8 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.8.0
+  #GIT_TAG        release-1.8.0
+  GIT_TAG        v1.14.0
 )
 
 FetchContent_GetProperties(googletest)

--- a/src/artff/buffer/circular_frame_buffer.h
+++ b/src/artff/buffer/circular_frame_buffer.h
@@ -4,7 +4,9 @@
 #include <vector>
 #include <complex>
 
-
+#ifdef __linux__
+#include <cstdint>
+#endif
 
 namespace artff {
 class CircularFrameBuffer {

--- a/src/artff/buffer/circular_frame_buffer.h
+++ b/src/artff/buffer/circular_frame_buffer.h
@@ -4,9 +4,7 @@
 #include <vector>
 #include <complex>
 
-#ifdef __linux__
-#include <cstdint>
-#endif
+
 
 namespace artff {
 class CircularFrameBuffer {

--- a/src/artff/buffer/circular_frame_buffer.h
+++ b/src/artff/buffer/circular_frame_buffer.h
@@ -4,6 +4,10 @@
 #include <vector>
 #include <complex>
 
+#ifdef __linux__
+#include <cstdint>
+#endif
+
 namespace artff {
 class CircularFrameBuffer {
 public:


### PR DESCRIPTION
Updates
- Updated CMake version.
- Upgraded GTest version.
- Added a condition for the download of spleeter models
- Included `<cstdint>` in the CircularFrameBuffer class for Linux builds.